### PR TITLE
fix CVE-2018-1324, update version of depenency library commons-compress.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>jp.cafebabe</groupId>
   <artifactId>traverser</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
 
   <name>traverser</name>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.13</version>
+      <version>1.19</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Also, update version of traverser to 1.0.1.